### PR TITLE
fix: center-align text in About component table cells

### DIFF
--- a/src/components/Page/About/index.tsx
+++ b/src/components/Page/About/index.tsx
@@ -122,7 +122,7 @@ From 2025, he is currently serving as an English teacher in Laos with JICA Overs
                           sm: "20%",
                           md: "15%",
                         },
-                        alignContent: "flex-start",
+                        alignContent: "center",
                       }}
                     >
                       <Typography level="body-md" fontWeight={"lg"}>
@@ -138,7 +138,7 @@ From 2025, he is currently serving as an English teacher in Laos with JICA Overs
                           md: "80%",
                         },
                         height: "auto",
-                        alignContent: "flex-start",
+                        alignContent: "center",
                       }}
                     >
                       <Typography level="body-md">{row.value}</Typography>


### PR DESCRIPTION
## Summary
- Changed alignContent from 'flex-start' to 'center' for both key and value cells in the About component table
- Improves visual alignment by centering text vertically within table cells

## Test plan
- [x] Verified changes work locally with development server
- [x] Confirmed table cells are properly center-aligned using Playwright browser testing

🤖 Generated with [Claude Code](https://claude.ai/code)