### PR TITLE
fix: resolve React key prop warnings and test failures

### DIFF
--- a/src/components/Page/About/index.tsx
+++ b/src/components/Page/About/index.tsx
@@ -123,40 +123,38 @@ From 2025, he is currently serving as an English teacher in Laos with JICA Overs
                   }),
                 },
               ].map((row) => (
-                <>
-                  <tr key={row.key}>
-                    <Box
-                      component="td"
-                      sx={{
-                        height: "auto",
-                        width: {
-                          xs: "30%",
-                          sm: "20%",
-                          md: "15%",
-                        },
-                        alignContent: "center",
-                      }}
-                    >
-                      <Typography level="body-md" fontWeight={"lg"}>
-                        {row.key}:
-                      </Typography>
-                    </Box>
-                    <Box
-                      component="td"
-                      sx={{
-                        width: {
-                          xs: "70%",
-                          sm: "75%",
-                          md: "80%",
-                        },
-                        height: "auto",
-                        alignContent: "center",
-                      }}
-                    >
-                      <Typography level="body-md">{row.value}</Typography>
-                    </Box>
-                  </tr>
-                </>
+                <tr key={row.key}>
+                  <Box
+                    component="td"
+                    sx={{
+                      height: "auto",
+                      width: {
+                        xs: "30%",
+                        sm: "20%",
+                        md: "15%",
+                      },
+                      alignContent: "center",
+                    }}
+                  >
+                    <Typography level="body-md" fontWeight={"lg"}>
+                      {row.key}:
+                    </Typography>
+                  </Box>
+                  <Box
+                    component="td"
+                    sx={{
+                      width: {
+                        xs: "70%",
+                        sm: "75%",
+                        md: "80%",
+                      },
+                      height: "auto",
+                      alignContent: "center",
+                    }}
+                  >
+                    <Typography level="body-md">{row.value}</Typography>
+                  </Box>
+                </tr>
               ))}
             </tbody>
           </Table>

--- a/src/components/Page/Header/LangSelector/LangSelector.stories.tsx
+++ b/src/components/Page/Header/LangSelector/LangSelector.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, screen, userEvent, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { LangSelector } from ".";
 
 const metaData: Meta = {
@@ -20,6 +20,8 @@ export const Default: StoryObj<typeof LangSelector> = {
 
     await userEvent.click(canvas.getByRole("button"));
 
+    // Wait for menu to open and items to be rendered - menu renders in body
+    await waitFor(() => screen.getByRole("menu"));
     const items = screen.getAllByRole("menuitem");
     for (const item of items) {
       const div = item.children[0] as HTMLDivElement;
@@ -46,6 +48,8 @@ export const SubDirectory: StoryObj<typeof LangSelector> = {
 
     await userEvent.click(canvas.getByRole("button"));
 
+    // Wait for menu to open and items to be rendered - menu renders in body
+    await waitFor(() => screen.getByRole("menu"));
     const items = screen.getAllByRole("menuitem");
     for (const item of items) {
       const div = item.children[0] as HTMLDivElement;
@@ -77,6 +81,9 @@ export const LaotianLanguage: StoryObj<typeof LangSelector> = {
 
     await userEvent.click(laosButton);
 
+    // Wait for menu to open and items to be rendered - menu renders in body
+    await waitFor(() => screen.getByRole("menu"));
+
     // 全ての言語オプションが表示されることを確認
     const items = screen.getAllByRole("menuitem");
     expect(items).toHaveLength(3); // ja, en, lo
@@ -97,6 +104,9 @@ export const LaotianBlogPage: StoryObj<typeof LangSelector> = {
     const canvas = within(canvasElement);
 
     await userEvent.click(canvas.getByRole("button", { name: "🇱🇦" }));
+
+    // Wait for menu to open and items to be rendered - menu renders in body
+    await waitFor(() => screen.getByRole("menu"));
 
     // ブログページでのラオス語言語切り替えが機能することを確認
     const laosMenuItem = screen.getByText("🇱🇦 ລາວ");

--- a/src/components/ServiceLinkCards/ServiceLinkCard/index.tsx
+++ b/src/components/ServiceLinkCards/ServiceLinkCard/index.tsx
@@ -63,9 +63,8 @@ export const ServiceLinkCard = ({
       <CardContent orientation="horizontal">
         {tags?.map((tag, index) => {
           return (
-            <>
+            <div key={tag} style={{ display: "contents" }}>
               <Typography
-                key={tag}
                 level="body-xs"
                 fontWeight="sm"
                 textColor="text.secondary"
@@ -73,7 +72,7 @@ export const ServiceLinkCard = ({
                 {tag.startsWith("#") ? tag : `＃${tag}`}
               </Typography>
               {index !== tags.length - 1 && <Divider orientation="vertical" />}
-            </>
+            </div>
           );
         })}
       </CardContent>

--- a/src/components/ServiceLinkCards/ServiceLinkCards.stories.tsx
+++ b/src/components/ServiceLinkCards/ServiceLinkCards.stories.tsx
@@ -19,18 +19,18 @@ const defaultArgs: ReactProps<typeof ServiceLinkCards> = {
       tags: ["Nature", "Mountain", "Lake"],
     },
     {
-      title: "Yosemite National Park",
-      description: "California, USA",
+      title: "Grand Canyon National Park",
+      description: "Arizona, USA",
       cardImg:
         "https://images.unsplash.com/photo-1532614338840-ab30cf10ed36?auto=format&fit=crop&w=318",
-      tags: ["Nature", "Mountain", "Lake"],
+      tags: ["Nature", "Canyon", "Desert"],
     },
     {
-      title: "Yosemite National Park",
-      description: "California, USA",
+      title: "Yellowstone National Park",
+      description: "Wyoming, USA",
       cardImg:
         "https://images.unsplash.com/photo-1532614338840-ab30cf10ed36?auto=format&fit=crop&w=318",
-      tags: ["Nature", "Mountain", "Lake"],
+      tags: ["Nature", "Geysers", "Wildlife"],
     },
   ],
 };

--- a/src/components/ServiceLinkCards/index.tsx
+++ b/src/components/ServiceLinkCards/index.tsx
@@ -21,19 +21,17 @@ export const ServiceLinkCards = ({ serviceLinkCard = [] }: Props) => (
       display={{ xs: "none", sm: "flex" }}
     >
       {serviceLinkCard.map((card) => (
-        <>
-          <Grid
-            key={card.title}
-            xs={12}
-            sm={6}
-            md={4}
-            lg={3}
-            textAlign={"left"}
-            sx={{ display: "flex", justifyContent: "center" }}
-          >
-            <ServiceLinkCard key={card.title} {...card} />
-          </Grid>
-        </>
+        <Grid
+          key={card.title}
+          xs={12}
+          sm={6}
+          md={4}
+          lg={3}
+          textAlign={"left"}
+          sx={{ display: "flex", justifyContent: "center" }}
+        >
+          <ServiceLinkCard {...card} />
+        </Grid>
       ))}
     </Grid>
 
@@ -49,16 +47,14 @@ export const ServiceLinkCards = ({ serviceLinkCard = [] }: Props) => (
       display={{ xs: "flex", sm: "none" }}
     >
       {serviceLinkCard.map((card) => (
-        <>
-          <Grid
-            key={card.title}
-            xs={12}
-            textAlign={"left"}
-            sx={{ display: "flex", justifyContent: "center" }}
-          >
-            <ServiceLinkCardMobile key={card.title} {...card} />
-          </Grid>
-        </>
+        <Grid
+          key={card.title}
+          xs={12}
+          textAlign={"left"}
+          sx={{ display: "flex", justifyContent: "center" }}
+        >
+          <ServiceLinkCardMobile {...card} />
+        </Grid>
       ))}
     </Grid>
   </>

--- a/src/components/SocialNetworks/SocialNetworksTemplate/index.tsx
+++ b/src/components/SocialNetworks/SocialNetworksTemplate/index.tsx
@@ -18,18 +18,16 @@ export const SocialNetworksTemplate = ({ socialLinks }: Props) => (
     marginBottom={"1rem"}
   >
     {socialLinks.map((card) => (
-      <>
-        <Grid
-          key={card.title}
-          xs={12}
-          sm={6}
-          md={4}
-          textAlign={"left"}
-          sx={{ display: "flex", justifyContent: "center" }}
-        >
-          <ServiceLinkCardMobile key={card.title} {...card} />
-        </Grid>
-      </>
+      <Grid
+        key={card.title}
+        xs={12}
+        sm={6}
+        md={4}
+        textAlign={"left"}
+        sx={{ display: "flex", justifyContent: "center" }}
+      >
+        <ServiceLinkCardMobile {...card} />
+      </Grid>
     ))}
   </Grid>
 );


### PR DESCRIPTION
## Summary
Fix React key prop warnings and test failures that were appearing in the test output.

## Test plan
- [x] All unit tests pass without warnings
- [x] All Storybook tests pass without warnings  
- [x] All e2e tests pass
- [x] Code formatting with Biome passes

## Changes
- Remove unnecessary React fragments causing missing key warnings in ServiceLinkCards, About, SocialNetworksTemplate components
- Fix duplicate key issues in ServiceLinkCards stories by using unique titles
- Update LangSelector tests to properly handle Joy UI menu portals that render outside component tree
- Improve test reliability by using waitFor and proper element scoping

🤖 Generated with [Claude Code](https://claude.ai/code)