### PR TITLE
ci: add Claude Code Action workflow for PR assistance

### DIFF
--- a/.github/workflows/claude-code-action.yaml
+++ b/.github/workflows/claude-code-action.yaml
@@ -1,0 +1,40 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-code-action:
+    if: |
+      contains(fromJson('["korosuke613", "Amybystara"]'), github.event.comment.user.login) &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
+    runs-on: ubuntu-latest
+    environment: claude-code-action
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"


### PR DESCRIPTION
Add GitHub Actions workflow to enable Claude PR Assistant for automated code review and issue assistance. The workflow triggers on @claude mentions in issues, PRs, and reviews.

🤖 Generated with [Claude Code](https://claude.ai/code)